### PR TITLE
Add settings button to mobile navigation menu

### DIFF
--- a/app.js
+++ b/app.js
@@ -35,7 +35,9 @@ class OceanCrestApp {
     document.addEventListener("click", (e) => {
       if (
         e.target.id === "settingsToggle" ||
-        e.target.closest("#settingsToggle")
+        e.target.closest("#settingsToggle") ||
+        e.target.id === "desktopSettingsToggle" ||
+        e.target.closest("#desktopSettingsToggle")
       ) {
         this.toggleSettingsPanel();
       }

--- a/app.js
+++ b/app.js
@@ -280,6 +280,16 @@ class OceanCrestApp {
       mobileNavMenu.appendChild(mobileLink);
     });
 
+    // Add settings button to mobile menu
+    const settingsButton = document.createElement("button");
+    settingsButton.className = "mobile-nav-settings";
+    settingsButton.innerHTML = "⚙️ Settings";
+    settingsButton.addEventListener("click", () => {
+      this.toggleSettingsPanel();
+      this.closeMobileNav(); // Close mobile menu when settings is opened
+    });
+    mobileNavMenu.appendChild(settingsButton);
+
     mobileOverlay.appendChild(mobileNavMenu);
 
     // Add to DOM

--- a/app.js
+++ b/app.js
@@ -62,7 +62,8 @@ class OceanCrestApp {
       // Close settings panel when clicking outside
       if (
         !e.target.closest(".settings-panel") &&
-        !e.target.closest("#settingsToggle")
+        !e.target.closest("#settingsToggle") &&
+        !e.target.closest("#desktopSettingsToggle")
       ) {
         this.closeSettingsPanel();
       }

--- a/index.html
+++ b/index.html
@@ -152,6 +152,15 @@
                   >Contact<span class="nav-indicator"></span
                 ></a>
               </li>
+              <li>
+                <button
+                  class="desktop-settings-btn"
+                  id="desktopSettingsToggle"
+                  aria-label="Open settings"
+                >
+                  ⚙️<span class="nav-indicator"></span>
+                </button>
+              </li>
             </ul>
           </nav>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -221,17 +221,21 @@
   transform: translateY(0);
 }
 
-.mobile-nav-menu a {
-  font-size: 2rem;
+.mobile-nav-menu a,
+.mobile-nav-settings {
+  font-size: 1.5rem;
   font-weight: 600;
   color: var(--text-primary);
   text-decoration: none;
-  padding: 1rem 2rem;
+  padding: 0.8rem 1.5rem;
   border-radius: 12px;
   transition: all 0.3s ease;
   background: linear-gradient(135deg, transparent 0%, transparent 100%);
   position: relative;
   overflow: hidden;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
 }
 
 .mobile-nav-menu a::before {

--- a/styles.css
+++ b/styles.css
@@ -238,7 +238,8 @@
   font-family: inherit;
 }
 
-.mobile-nav-menu a::before {
+.mobile-nav-menu a::before,
+.mobile-nav-settings::before {
   content: "";
   position: absolute;
   top: 0;
@@ -250,11 +251,13 @@
   z-index: -1;
 }
 
-.mobile-nav-menu a:hover::before {
+.mobile-nav-menu a:hover::before,
+.mobile-nav-settings:hover::before {
   left: 0;
 }
 
-.mobile-nav-menu a:hover {
+.mobile-nav-menu a:hover,
+.mobile-nav-settings:hover {
   color: var(--primary-bg);
   transform: scale(1.05);
   box-shadow: 0 10px 30px rgba(0, 191, 255, 0.3);
@@ -263,6 +266,12 @@
 .mobile-nav-menu a.active {
   background: var(--accent-gradient);
   color: var(--primary-bg);
+}
+
+.mobile-nav-settings {
+  margin-top: 1rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  padding-top: 1.5rem;
 }
 
 /* Enhanced Glass Morphism Effects */

--- a/styles.css
+++ b/styles.css
@@ -2464,11 +2464,19 @@ nav a.active {
   }
 
   .settings-panel {
-    width: 280px;
+    width: auto;
     bottom: 1rem;
     right: 1rem;
     left: 1rem;
-    width: auto;
+    max-width: 320px;
+    margin: 0 auto;
+    position: fixed;
+    top: 50%;
+    transform: translateY(-50%) scale(0.95);
+  }
+
+  .settings-panel.active {
+    transform: translateY(-50%) scale(1);
   }
 
   /* Particles disabled on mobile for performance */

--- a/styles.css
+++ b/styles.css
@@ -2456,19 +2456,17 @@ nav a.active {
     margin: 1rem;
   }
 
-  /* Settings toggle positioning */
+  /* Hide settings toggle on mobile since it's in the menu */
   .settings-toggle {
-    width: 50px;
-    height: 50px;
-    font-size: 1.2rem;
-    bottom: 1rem;
-    right: 1rem;
+    display: none;
   }
 
   .settings-panel {
     width: 280px;
-    bottom: 70px;
+    bottom: 1rem;
     right: 1rem;
+    left: 1rem;
+    width: auto;
   }
 
   /* Particles disabled on mobile for performance */

--- a/styles.css
+++ b/styles.css
@@ -2480,9 +2480,10 @@ nav a.active {
     font-size: 2rem;
   }
 
-  .mobile-nav-menu a {
-    font-size: 1.5rem;
-    padding: 0.8rem 1.5rem;
+  .mobile-nav-menu a,
+  .mobile-nav-settings {
+    font-size: 1.2rem;
+    padding: 0.6rem 1.2rem;
   }
 
   .section {

--- a/styles.css
+++ b/styles.css
@@ -2482,10 +2482,14 @@ nav a.active {
     font-size: 2rem;
   }
 
+  .mobile-nav-menu {
+    gap: 0.5rem;
+  }
+
   .mobile-nav-menu a,
   .mobile-nav-settings {
-    font-size: 1.2rem;
-    padding: 0.6rem 1.2rem;
+    font-size: 1rem;
+    padding: 0.5rem 1rem;
   }
 
   .section {

--- a/styles.css
+++ b/styles.css
@@ -212,9 +212,11 @@
   justify-content: center;
   align-items: center;
   height: 100%;
-  gap: 2rem;
+  gap: 1rem;
   transform: translateY(50px);
   transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  padding: 2rem 0;
+  overflow-y: auto;
 }
 
 .mobile-nav-overlay.active .mobile-nav-menu {


### PR DESCRIPTION
This change adds a settings button to the mobile navigation menu and updates the mobile layout for better usability.

Changes made:
- Added settings button to mobile navigation menu with gear icon
- Settings button triggers settings panel and closes mobile menu
- Reduced gap between mobile nav items from 2rem to 1rem
- Added padding and overflow-y auto to mobile nav menu
- Updated font sizes for mobile nav items from 2rem to 1.5rem
- Applied consistent styling to both nav links and settings button
- Added hover effects and transitions to settings button
- Styled settings button with top border and margin separation
- Hidden desktop settings toggle on mobile devices
- Repositioned settings panel to be centered and responsive on mobile
- Further reduced mobile nav item sizes on smaller screens (1rem font, 0.5rem padding)

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 19`

🔗 [Edit in Builder.io](https://builder.io/app/projects/016b223e95d04e32a6d799723b000fb2/stellar-realm)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>016b223e95d04e32a6d799723b000fb2</projectId>-->
<!--<branchName>stellar-realm</branchName>-->