### PR TITLE
Add desktop settings button to navigation

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -4301,6 +4301,47 @@ footer::before {
   .filter-select {
     min-width: 120px;
   }
+}
+
+/* Desktop styles for larger screens */
+@media (min-width: 769px) {
+  /* Show desktop settings button in navigation */
+  .desktop-settings-btn {
+    display: flex !important;
+  }
+
+  /* Hide the floating settings toggle on desktop when we have the nav button */
+  .settings-toggle {
+    display: none !important;
+  }
+
+  /* Ensure navigation is visible */
+  nav ul {
+    display: flex;
+  }
+
+  .mobile-nav-toggle {
+    display: none;
+  }
+
+  .mobile-nav-overlay {
+    display: none;
+  }
+
+  /* Desktop settings panel positioning */
+  .settings-panel {
+    position: fixed;
+    bottom: auto;
+    right: 1.5rem;
+    left: auto;
+    top: 70px;
+    width: 320px;
+    transform: translateY(-20px) scale(0.95);
+  }
+
+  .settings-panel.active {
+    transform: translateY(0) scale(1);
+  }
 
   .admin-stats {
     gap: 1rem;

--- a/styles.css
+++ b/styles.css
@@ -703,6 +703,51 @@ nav a.active {
   justify-content: center;
 }
 
+/* Desktop settings button in navigation */
+.desktop-settings-btn {
+  background: var(--glass-bg);
+  backdrop-filter: blur(20px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  color: var(--text-primary);
+  font-size: 1.2rem;
+  cursor: pointer;
+  padding: 0.5rem;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  width: 40px;
+  height: 40px;
+}
+
+.desktop-settings-btn:hover {
+  transform: scale(1.1) rotate(90deg);
+  background: var(--accent-gradient);
+  color: var(--primary-bg);
+  box-shadow: 0 4px 20px rgba(0, 191, 255, 0.3);
+}
+
+.desktop-settings-btn:active {
+  transform: scale(0.95);
+}
+
+.desktop-settings-btn .nav-indicator {
+  position: absolute;
+  bottom: -8px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 0;
+  height: 2px;
+  background: var(--accent-gradient);
+  transition: width 0.3s ease;
+}
+
+.desktop-settings-btn:hover .nav-indicator {
+  width: 100%;
+}
+
 .settings-toggle:hover {
   transform: scale(1.1) rotate(90deg);
   box-shadow: 0 8px 25px rgba(0, 191, 255, 0.3);
@@ -2463,9 +2508,14 @@ nav a.active {
     display: none;
   }
 
+  /* Keep desktop settings button visible on desktop only */
+  .desktop-settings-btn {
+    display: none;
+  }
+
   .settings-panel {
-    width: auto;
-    bottom: 1rem;
+    width: calc(100vw - 2rem);
+    bottom: auto;
     right: 1rem;
     left: 1rem;
     max-width: 320px;
@@ -2473,6 +2523,7 @@ nav a.active {
     position: fixed;
     top: 50%;
     transform: translateY(-50%) scale(0.95);
+    z-index: 1003;
   }
 
   .settings-panel.active {

--- a/styles.css
+++ b/styles.css
@@ -4330,17 +4330,18 @@ footer::before {
 
   /* Desktop settings panel positioning */
   .settings-panel {
-    position: fixed;
+    position: absolute;
     bottom: auto;
-    right: 1.5rem;
+    right: 0;
     left: auto;
-    top: 70px;
+    top: 100%;
     width: 320px;
-    transform: translateY(-20px) scale(0.95);
+    transform: translateY(10px) scale(0.95);
+    margin-top: 0.5rem;
   }
 
   .settings-panel.active {
-    transform: translateY(0) scale(1);
+    transform: translateY(10px) scale(1);
   }
 
   .admin-stats {


### PR DESCRIPTION
Add a new desktop settings button to the navigation bar with the following changes:

- Add `.desktop-settings-btn` class with glass morphism styling, hover effects, and rotation animation
- Include a nav indicator that expands on hover
- Hide desktop settings button on mobile devices (display: none below 769px)
- Show desktop settings button on screens 769px and wider
- Hide the floating settings toggle on desktop when navigation button is present
- Reposition settings panel for desktop: absolute positioning below navigation with proper transforms
- Update mobile settings panel width to use calc(100vw - 2rem) and add z-index: 1003
- Ensure mobile navigation elements are properly hidden on desktop

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 20`

🔗 [Edit in Builder.io](https://builder.io/app/projects/85d2fff669ff43079a5942d946b88b30/flare-world)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>85d2fff669ff43079a5942d946b88b30</projectId>-->
<!--<branchName>flare-world</branchName>-->